### PR TITLE
README.md project name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Forsquare-CollectionPicker
+# Foursquare-CollectionPicker
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.anton46/collection-picker/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.anton46/collection-picker/) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Foursquare--CollectionPicker-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1560) [![API](https://img.shields.io/badge/API-14%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=14)
 
 


### PR DESCRIPTION
Just a typo, but the first word in README.md

Thanks for the good library btw.
